### PR TITLE
0.22: Improve errors and deserialization types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
  "sha2",
  "ssri",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "walkdir",
@@ -1188,7 +1188,7 @@ checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
 dependencies = [
  "miette-derive",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-width",
 ]
 
@@ -1249,6 +1249,7 @@ dependencies = [
  "serde_json_diff",
  "serde_with",
  "strum",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1649,7 +1650,7 @@ dependencies = [
  "http",
  "reqwest",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tower-service",
 ]
 
@@ -2017,7 +2018,7 @@ dependencies = [
  "serde",
  "sha-1",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "xxhash-rust",
 ]
 
@@ -2132,7 +2133,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2140,6 +2150,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde_json_diff = ["dep:serde_json_diff"]
 [dev-dependencies]
 serde_json_diff = "0.1.1"
 tracing-test = "0.2.5"
+tracing-subscriber = "0.3.19"
 
 [dependencies]
 async-stream = { version = "0.3.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ name = "parser"
 required-features = ["bin"]
 
 [features]
-bin = ["dep:clap", "dep:tracing-subscriber", "dep:tokio", "dep:futures", "dep:reqwest", "dep:reqwest-middleware", "dep:http-cache-reqwest", "dep:async-stream", "dep:serde_json_diff"]
-serde_json_diff = ["dep:serde_json_diff"]
+bin = ["dep:clap", "dep:tracing-subscriber", "dep:tokio", "dep:futures", "dep:reqwest", "dep:reqwest-middleware", "dep:http-cache-reqwest", "dep:async-stream", "dep:serde_json_diff", "serde_json/raw_value"]
 
 [dev-dependencies]
 serde_json_diff = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = "1.0.140"
 serde_json_diff = { version = "0.1.1", optional = true }
 serde_with = { version = "3.14.0", features = ["macros"] }
 strum = { version = "0.27.1", features = ["derive"] }
+thiserror = "2.0.12"
 tokio = { version = "1.44.2", features = ["full"], optional = true }
 tracing = { version = "0.1.41" }
 tracing-subscriber = { version = "0.3.19", optional = true }

--- a/src/bin/parser.rs
+++ b/src/bin/parser.rs
@@ -180,13 +180,10 @@ async fn ingest_game(response: EntityResponse<Box<serde_json::value::RawValue>>,
 
         let parsed_event_message = process_event(event, &game, &response.entity_id);
         if tracing::enabled!(Level::ERROR) {
-            if let Ok(parsed_event_message) = &parsed_event_message {
-                let unparsed = parsed_event_message.unparse(&game, event.index);
-                if event.message != unparsed {
-                    error!("Event round trip failure expected:\n'{}'\nGot:\n'{}'", event.message, unparsed);
-                }
+            let unparsed = parsed_event_message.unparse(&game, event.index);
+            if event.message != unparsed {
+                error!("Event round trip failure expected:\n'{}'\nGot:\n'{}'", event.message, unparsed);
             }
-
         }
 
         if args.verbose {
@@ -230,11 +227,9 @@ async fn ingest_team(response: EntityResponse<Box<serde_json::value::RawValue>>,
 
         let parsed_text = parse_feed_event(&event);
         if tracing::enabled!(Level::ERROR) {
-            if let Ok(parsed_text) = &parsed_text {
-                let unparsed = parsed_text.unparse(&event, FeedEventSource::Team);
-                if event.text != unparsed {
-                    error!("Feed event round trip failure expected:\n'{}'\nGot:\n'{}'", event.text, unparsed);
-                }
+            let unparsed = parsed_text.unparse(&event, FeedEventSource::Team);
+            if event.text != unparsed {
+                error!("Feed event round trip failure expected:\n'{}'\nGot:\n'{}'", event.text, unparsed);
             }
         }
 
@@ -277,11 +272,9 @@ async fn ingest_player(response: EntityResponse<Box<serde_json::value::RawValue>
 
         let parsed_text = parse_feed_event(&event);
         if tracing::enabled!(Level::ERROR) {
-            if let Ok(parsed_text) = &parsed_text {
-                let unparsed = parsed_text.unparse(&event, FeedEventSource::Player);
-                if event.text != unparsed {
-                    error!("Feed event round trip failure expected:\n'{}'\nGot:\n'{}'", event.text, unparsed);
-                }
+            let unparsed = parsed_text.unparse(&event, FeedEventSource::Player);
+            if event.text != unparsed {
+                error!("Feed event round trip failure expected:\n'{}'\nGot:\n'{}'", event.text, unparsed);
             }
         }
 

--- a/src/bin/parser.rs
+++ b/src/bin/parser.rs
@@ -180,10 +180,13 @@ async fn ingest_game(response: EntityResponse<Box<serde_json::value::RawValue>>,
 
         let parsed_event_message = process_event(event, &game, &response.entity_id);
         if tracing::enabled!(Level::ERROR) {
-            let unparsed = parsed_event_message.clone().unparse(&game, event.index);
-            if event.message != unparsed {
-                error!("Event round trip failure expected:\n'{}'\nGot:\n'{}'", event.message, unparsed);
+            if let Ok(parsed_event_message) = &parsed_event_message {
+                let unparsed = parsed_event_message.unparse(&game, event.index);
+                if event.message != unparsed {
+                    error!("Event round trip failure expected:\n'{}'\nGot:\n'{}'", event.message, unparsed);
+                }
             }
+
         }
 
         if args.verbose {
@@ -227,9 +230,11 @@ async fn ingest_team(response: EntityResponse<Box<serde_json::value::RawValue>>,
 
         let parsed_text = parse_feed_event(&event);
         if tracing::enabled!(Level::ERROR) {
-            let unparsed = parsed_text.unparse(&event, FeedEventSource::Team);
-            if event.text != unparsed {
-                error!("Feed event round trip failure expected:\n'{}'\nGot:\n'{}'", event.text, unparsed);
+            if let Ok(parsed_text) = &parsed_text {
+                let unparsed = parsed_text.unparse(&event, FeedEventSource::Team);
+                if event.text != unparsed {
+                    error!("Feed event round trip failure expected:\n'{}'\nGot:\n'{}'", event.text, unparsed);
+                }
             }
         }
 
@@ -272,9 +277,11 @@ async fn ingest_player(response: EntityResponse<Box<serde_json::value::RawValue>
 
         let parsed_text = parse_feed_event(&event);
         if tracing::enabled!(Level::ERROR) {
-            let unparsed = parsed_text.unparse(&event, FeedEventSource::Player);
-            if event.text != unparsed {
-                error!("Feed event round trip failure expected:\n'{}'\nGot:\n'{}'", event.text, unparsed);
+            if let Ok(parsed_text) = &parsed_text {
+                let unparsed = parsed_text.unparse(&event, FeedEventSource::Player);
+                if event.text != unparsed {
+                    error!("Feed event round trip failure expected:\n'{}'\nGot:\n'{}'", event.text, unparsed);
+                }
             }
         }
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,4 +1,4 @@
-use std::{any::type_name, convert::Infallible, fmt::Display, str::FromStr};
+use std::{fmt::{Debug, Display}, str::FromStr};
 
 use nom::{branch::alt, bytes::complete::tag, character::complete::u8, combinator::{all_consuming, opt}, sequence::{preceded, separated_pair, terminated}, Parser};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
@@ -686,12 +686,12 @@ impl Display for BatterStat {
             BatterStat::HitByPitchs(count) |
             BatterStat::StrikeOuts(count) |
             BatterStat::GroundOuts(count) => {
-                format!("{count} {}", BatterStatDiscriminants::from(self))
+                write!(f, "{count} {}", BatterStatDiscriminants::from(self))
             }
             BatterStat::HitsForAtBats { hits, at_bats } => {
-                format!("{hits} for {at_bats}")
+                write!(f, "{hits} for {at_bats}")
             }
-        }.fmt(f)
+        }
     }
 }
 
@@ -957,13 +957,13 @@ fn postseason_round_de<'de, D>(deserializer: D) -> Result<u8, D::Error> where D:
 impl Display for Day {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::SuperstarBreak => "Superstar Break".fmt(f),
-            Self::Day(d) => d.fmt(f),
-            Self::Preseason => "Preseason".fmt(f),
-            Self::Holiday => "Holiday".fmt(f),
-            Self::Election => "Election".fmt(f),
+            Self::SuperstarBreak => write!(f, "Superstar Break"),
+            Self::Day(d) => write!(f, "{}", d),
+            Self::Preseason => write!(f, "Preseason"),
+            Self::Holiday => write!(f, "Holiday"),
+            Self::Election => write!(f, "Election"),
             Self::SuperstarDay(d) => write!(f, "Superstar Day {d}"),
-            Self::PostseasonPreview => "Postseason Preview".fmt(f),
+            Self::PostseasonPreview => write!(f, "Postseason Preview"),
             Self::PostseasonRound(r) => write!(f, "Postseason Round {r}")
         }
     }
@@ -981,95 +981,6 @@ pub enum PositionType {
     Pitcher,
     Batter,
 }
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum MaybeRecognized<T> {
-    Recognized(T),
-    NotRecognized(serde_json::Value)
-}
-
-impl<T> MaybeRecognized<T> {
-    pub fn into_inner(self) -> Option<T> {
-        match self {
-            MaybeRecognized::Recognized(t) => Some(t),
-            MaybeRecognized::NotRecognized(_) => None
-        }  
-    }
-    pub fn inner(&self) -> Option<&T> {
-        match self {
-            MaybeRecognized::Recognized(t) => Some(t),
-            MaybeRecognized::NotRecognized(_) => None
-        }
-    }
-}
-
-impl<T: FromStr> FromStr for MaybeRecognized<T> {
-    type Err = Infallible;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::from(s))
-    }
-}
-
-impl<T: FromStr> From<&str> for MaybeRecognized<T> {
-    fn from(value: &str) -> Self {
-        T::from_str(value).map(MaybeRecognized::Recognized)
-            .unwrap_or_else(|_| {
-                tracing::error!("{value:?} not recognized as {}", type_name::<T>());
-                MaybeRecognized::NotRecognized(serde_json::Value::String(value.to_string()))
-            }
-        )
-    }
-}
-
-impl<T: FromStr> From<String> for MaybeRecognized<T> {
-    fn from(value: String) -> Self {
-        Self::from(value.as_str())
-    }
-}
-
-impl<T: Display> Display for MaybeRecognized<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            MaybeRecognized::Recognized(t) => t.fmt(f),
-            MaybeRecognized::NotRecognized(s) => s.fmt(f)
-        }
-    }
-}
-
-impl<'de, T:Deserialize<'de>> Deserialize<'de> for MaybeRecognized<T> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: serde::Deserializer<'de> {
-        
-        #[derive(Serialize, Deserialize)]
-        enum Visitor<T> {
-            #[serde(untagged)]
-            Recognized(T),
-            #[serde(untagged)]
-            Other(serde_json::Value)
-        }
-        match Visitor::<T>::deserialize(deserializer) {
-            Ok(Visitor::Recognized(t)) => Ok(MaybeRecognized::Recognized(t)),
-            Ok(Visitor::Other(s)) => {
-                tracing::error!("{s:?} not recognized as {}", type_name::<T>());
-                Ok(MaybeRecognized::NotRecognized(s))
-            }
-            Err(e) => Err(e)
-        }
-    }
-}
-
-impl<T: Serialize> Serialize for MaybeRecognized<T> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: serde::Serializer {
-        match self {
-            MaybeRecognized::Recognized(t) => t.serialize(serializer),
-            MaybeRecognized::NotRecognized(s) => s.serialize(serializer)
-        }
-    }
-}
-
 
 #[derive(Debug, Clone, Copy, EnumIter, PartialEq, Eq, Hash, EnumDiscriminants, SerializeDisplay, DeserializeFromStr)]
 #[strum_discriminants(derive(EnumString, Display))]

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -662,7 +662,7 @@ impl BatterStat {
     /// assert_eq!(BatterStat::FirstBases(1).unparse(), "1 1B");
     /// assert_eq!(BatterStat::HitsForAtBats{hits: 1, at_bats: 1}.unparse(), "1 for 1");
     /// ```
-    pub fn unparse(self) -> String {
+    pub fn unparse(&self) -> String {
         self.to_string()
     }
 }

--- a/src/feed_event/feed_event.rs
+++ b/src/feed_event/feed_event.rs
@@ -1,16 +1,23 @@
 use serde::{Serialize, Deserialize};
-use crate::{enums::{Day, FeedEventType, MaybeRecognized, SeasonStatus}, feed_event::feed_event_text::FeedEventText, utils::ExtraFields};
+use serde_with::serde_as;
+use crate::{enums::{Day, FeedEventType, SeasonStatus}, feed_event::feed_event_text::FeedEventText, utils::{ExtraFields, MaybeRecognizedResult}};
+use crate::utils::MaybeRecognizedHelper;
 
+#[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct FeedEvent {
     pub emoji: String,
     pub season: u8,
-    pub day: MaybeRecognized<Day>,
-    pub status: MaybeRecognized<SeasonStatus>,
+    
+    #[serde_as(as = "MaybeRecognizedHelper<_>")]
+    pub day: MaybeRecognizedResult<Day>,
+    #[serde_as(as = "MaybeRecognizedHelper<_>")]
+    pub status: MaybeRecognizedResult<SeasonStatus>,
     pub text: FeedEventText,
     pub ts: String,
     #[serde(rename = "type")]
-    pub event_type: MaybeRecognized<FeedEventType>,
+    #[serde_as(as = "MaybeRecognizedHelper<_>")]
+    pub event_type: MaybeRecognizedResult<FeedEventType>,
 
     /// TODO
     pub(crate) links: serde_json::Value,

--- a/src/feed_event/feed_event.rs
+++ b/src/feed_event/feed_event.rs
@@ -1,6 +1,6 @@
 use serde::{Serialize, Deserialize};
 use serde_with::serde_as;
-use crate::{enums::{Day, FeedEventType, SeasonStatus}, feed_event::feed_event_text::FeedEventText, utils::{ExtraFields, MaybeRecognizedResult}};
+use crate::{enums::{Day, FeedEventType, SeasonStatus}, utils::{extra_fields_deserialize, MaybeRecognizedResult}};
 use crate::utils::MaybeRecognizedHelper;
 
 #[serde_as]
@@ -13,7 +13,7 @@ pub struct FeedEvent {
     pub day: MaybeRecognizedResult<Day>,
     #[serde_as(as = "MaybeRecognizedHelper<_>")]
     pub status: MaybeRecognizedResult<SeasonStatus>,
-    pub text: FeedEventText,
+    pub text: String,
     pub ts: String,
     #[serde(rename = "type")]
     #[serde_as(as = "MaybeRecognizedHelper<_>")]
@@ -22,22 +22,24 @@ pub struct FeedEvent {
     /// TODO
     pub(crate) links: serde_json::Value,
 
-    #[serde(flatten)]
-    pub extra_fields: ExtraFields,
+    #[serde(flatten, deserialize_with = "extra_fields_deserialize")]
+    pub extra_fields: serde_json::Map<String, serde_json::Value>,
 }
 
 #[cfg(test)]
 mod test {
     use std::path::Path;
 
-    use crate::{feed_event::FeedEvent, utils::assert_round_trip};
+    use crate::{feed_event::FeedEvent, utils::{assert_round_trip, no_tracing_errs}};
 
 
     #[test]
-    #[tracing_test::traced_test]
     fn feed_event_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+        let no_tracing_errs = no_tracing_errs();
+
         assert_round_trip::<FeedEvent>(Path::new("test_data/s2_feed_event.json"))?;
-        assert!(!logs_contain("not recognized"));
+        
+        drop(no_tracing_errs);
         Ok(())
     }
 }

--- a/src/feed_event/feed_event_text.rs
+++ b/src/feed_event/feed_event_text.rs
@@ -147,7 +147,7 @@ impl<S: Display> ParsedFeedEventText<S> {
             }
             ParsedFeedEventText::AttributeEquals { equals } => {
                 let f = |change: &AttributeEqual<S>| {
-                    if Breakpoints::S1AttributeEqualChange.after(event.season as u32, &event.day, None) {
+                    if Breakpoints::S1AttributeEqualChange.after(event.season as u32, event.day.as_ref().copied().ok(), None) {
                         format!("{}'s {} became equal to their current base {}.", change.player_name, change.changing_attribute, change.value_attribute)
                     } else if FeedEventSource::Player == source {
                         format!("{}'s {} was set to their {}.", change.player_name, change.changing_attribute, change.value_attribute)
@@ -161,7 +161,7 @@ impl<S: Display> ParsedFeedEventText<S> {
                     .join(" ")
             }
             ParsedFeedEventText::S1Enchantment { player_name, item, amount, attribute } => {
-                if Breakpoints::Season1EnchantmentChange.before(event.season as u32, &event.day, None) {
+                if Breakpoints::Season1EnchantmentChange.before(event.season as u32, event.day.as_ref().copied().ok(), None) {
                     format!("{player_name}'s {item} was enchanted with +{amount} to {attribute}.")
                 } else {
                     format!("The Item Enchantment was a success! {player_name}'s {item} gained a +{amount} {attribute} bonus.")

--- a/src/feed_event/feed_event_text.rs
+++ b/src/feed_event/feed_event_text.rs
@@ -1,43 +1,8 @@
-use std::{fmt::Display, ops::{Deref, DerefMut}};
+use std::fmt::Display;
 
 use serde::{Serialize, Deserialize};
 
-use crate::{enums::{Attribute, FeedEventSource, FeedEventType, ItemPrefix, ItemSuffix, ItemType}, feed_event::FeedEvent, nom_parsing::parse_feed_event, parsed_event::{EmojiTeam, Item}, time::Breakpoints};
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct FeedEventText(pub String);
-
-impl FeedEventText {
-    pub fn parse(&self, event_type: FeedEventType) -> ParsedFeedEventText<&str> {
-        parse_feed_event(self, event_type)
-    }
-    pub fn into_inner(self) -> String {
-        self.0
-    }
-}
-
-impl PartialEq<String> for FeedEventText {
-    fn eq(&self, other: &String) -> bool {
-        self.0.eq(other)
-    }
-}
-impl Display for FeedEventText {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl Deref for FeedEventText {
-    type Target = String;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl DerefMut for FeedEventText {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
+use crate::{enums::{Attribute, FeedEventSource, ItemPrefix, ItemSuffix, ItemType}, feed_event::FeedEvent, parsed_event::{EmojiTeam, Item}, time::Breakpoints};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum ParsedFeedEventText<S> {

--- a/src/feed_event/feed_event_text.rs
+++ b/src/feed_event/feed_event_text.rs
@@ -18,6 +18,10 @@ pub enum FeedEventParseError {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum ParsedFeedEventText<S> {
+    ParseError {
+        error: FeedEventParseError,
+        text: S
+    },
     GameResult {
         /// Sometimes this name is wrong: early season 1 bug where the events didn't have spaces between words.
         home_team: EmojiTeam<S>,
@@ -93,6 +97,7 @@ pub struct AttributeEqual<S> {
 impl<S: Display> ParsedFeedEventText<S> {
     pub fn unparse(&self, event: &FeedEvent, source: FeedEventSource) -> String {
         match self {
+            ParsedFeedEventText::ParseError { text, .. } => text.to_string(),
             ParsedFeedEventText::GameResult { home_team, away_team, home_score, away_score } => {
                 format!("{} vs. {} - FINAL {}-{}", away_team, home_team, away_score, home_score)
             }

--- a/src/feed_event/mod.rs
+++ b/src/feed_event/mod.rs
@@ -2,5 +2,5 @@ mod feed_event;
 mod feed_event_text;
 
 pub use feed_event::FeedEvent;
-pub use feed_event_text::{ParsedFeedEventText, AttributeChange, AttributeEqual, FeedDelivery, EmojilessItem};
+pub use feed_event_text::{ParsedFeedEventText, FeedEventParseError, AttributeChange, AttributeEqual, FeedDelivery, EmojilessItem};
 pub use crate::nom_parsing::parse_feed_event;

--- a/src/feed_event/mod.rs
+++ b/src/feed_event/mod.rs
@@ -2,5 +2,5 @@ mod feed_event;
 mod feed_event_text;
 
 pub use feed_event::FeedEvent;
-pub use feed_event_text::{FeedEventText, ParsedFeedEventText, AttributeChange, AttributeEqual, FeedDelivery, EmojilessItem};
+pub use feed_event_text::{ParsedFeedEventText, AttributeChange, AttributeEqual, FeedDelivery, EmojilessItem};
 pub use crate::nom_parsing::parse_feed_event;

--- a/src/game/event.rs
+++ b/src/game/event.rs
@@ -1,7 +1,10 @@
 use serde::{Serialize, Deserialize};
+use serde_with::serde_as;
 
-use crate::{enums::{EventType, Inning, MaybeRecognized}, game::{MaybePlayer, Pitch}, utils::{ExtraFields, SomeOrEmptyString}};
+use crate::{enums::{EventType, Inning}, game::{MaybePlayer, Pitch}, utils::{ExtraFields, MaybeRecognizedResult, SomeOrEmptyString}};
+use crate::utils::MaybeRecognizedHelper;
 
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct RawEvent {
     /// 0 is before the game has started
@@ -33,7 +36,8 @@ pub(crate) struct RawEvent {
 
     pub zone: SomeOrEmptyString<u8>,
 
-    pub event: MaybeRecognized<EventType>,
+    #[serde_as(as = "MaybeRecognizedHelper<_>")]
+    pub event: MaybeRecognizedResult<EventType>,
     pub message: String,
 
     pub index: SomeOrEmptyString<u16>,
@@ -42,6 +46,7 @@ pub(crate) struct RawEvent {
     pub extra_fields: ExtraFields,
 }
 
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(from = "RawEvent", into = "RawEvent")]
 pub struct Event {
@@ -64,7 +69,8 @@ pub struct Event {
 
     pub pitch: Option<Pitch>,
 
-    pub event: MaybeRecognized<EventType>,
+    #[serde_as(as = "MaybeRecognizedHelper<_>")]
+    pub event: MaybeRecognizedResult<EventType>,
     pub message: String,
 
     pub index: Option<u16>,

--- a/src/game/event.rs
+++ b/src/game/event.rs
@@ -1,7 +1,7 @@
 use serde::{Serialize, Deserialize};
 use serde_with::serde_as;
 
-use crate::{enums::{EventType, Inning}, game::{MaybePlayer, Pitch}, utils::{ExtraFields, MaybeRecognizedResult, SomeOrEmptyString}};
+use crate::{enums::{EventType, Inning}, game::{MaybePlayer, Pitch}, utils::{extra_fields_deserialize, MaybeRecognizedResult, SomeOrEmptyString}};
 use crate::utils::MaybeRecognizedHelper;
 
 #[serde_as]
@@ -34,16 +34,18 @@ pub(crate) struct RawEvent {
     /// Empty if none
     pub pitch_info: String,
 
-    pub zone: SomeOrEmptyString<u8>,
+    #[serde_as(as = "serde_with::FromInto<SomeOrEmptyString<u8>>")]
+    pub zone: Option<u8>,
 
     #[serde_as(as = "MaybeRecognizedHelper<_>")]
     pub event: MaybeRecognizedResult<EventType>,
     pub message: String,
 
-    pub index: SomeOrEmptyString<u16>,
+    #[serde_as(as = "serde_with::FromInto<SomeOrEmptyString<u16>>")]
+    pub index: Option<u16>,
 
-    #[serde(flatten)]
-    pub extra_fields: ExtraFields,
+    #[serde(flatten, deserialize_with = "extra_fields_deserialize")]
+    pub extra_fields: serde_json::Map<String, serde_json::Value>,
 }
 
 #[serde_as]
@@ -75,8 +77,8 @@ pub struct Event {
 
     pub index: Option<u16>,
 
-    #[serde(flatten)]
-    pub extra_fields: ExtraFields,
+    #[serde(flatten, deserialize_with = "extra_fields_deserialize")]
+    pub extra_fields: serde_json::Map<String, serde_json::Value>,
 }
 impl From<RawEvent> for Event {
     fn from(value: RawEvent) -> Self {

--- a/src/game/game.rs
+++ b/src/game/game.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{enums::{Day, GameStat, LeagueScale, SeasonStatus, Slot}, game::{Event, PitcherEntry, Weather}, utils::{AddedLaterResult, ExtraFields, MaybeRecognizedResult}};
+use crate::{enums::{Day, GameStat, LeagueScale, SeasonStatus, Slot}, game::{Event, PitcherEntry, Weather}, utils::{AddedLaterResult, extra_fields_deserialize, MaybeRecognizedResult}};
 use crate::utils::{MaybeRecognizedHelper, AddedLaterHelper};
 
 use serde::{Serialize, Deserialize};
@@ -71,6 +71,6 @@ pub struct Game {
 
     pub event_log: Vec<Event>,
 
-    #[serde(flatten)]
-    pub extra_fields: ExtraFields,
+    #[serde(flatten, deserialize_with = "extra_fields_deserialize")]
+    pub extra_fields: serde_json::Map<String, serde_json::Value>,
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -127,14 +127,15 @@ mod test {
 
     use tracing_test::traced_test;
 
-    use crate::{utils::assert_round_trip, Game};
+    use crate::{utils::{assert_round_trip, no_tracing_errs}, Game};
 
 
     #[test]
-    #[traced_test]
     fn game_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+        let no_tracing_errs = no_tracing_errs();
         assert_round_trip::<Game>(Path::new("test_data/s2_d240_game.json"))?;
-        assert!(!logs_contain("not recognized"));
+
+        drop(no_tracing_errs);
         Ok(())
     }
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Deserializer, Serialize};
-use crate::enums::{MaybeRecognized, PitchType};
+use serde_with::serde_as;
+
+use crate::enums::{PitchType};
+use crate::utils::{maybe_recognized_from_str, maybe_recognized_to_string, MaybeRecognizedHelper, MaybeRecognizedResult};
 
 pub(crate) mod game;
 pub(crate) mod event;
@@ -78,23 +81,25 @@ impl<S: PartialEq<&'static str>> From<Option<S>> for MaybePlayer<S> {
     }
 }
 
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Pitch  {
     pub speed: f32,
-    pub pitch_type: MaybeRecognized<PitchType>,
+    #[serde_as(as = "MaybeRecognizedHelper<_>")]
+    pub pitch_type: MaybeRecognizedResult<PitchType>,
     pub zone: u8,
 }
 impl Pitch {
     pub fn new(pitch_info: String, zone: u8) -> Self {
         let mut iter = pitch_info.split(" MPH ");
         let pitch_speed = iter.next().unwrap().parse().unwrap();
-        let pitch_type = iter.next().unwrap().into();
+        let pitch_type = maybe_recognized_from_str(iter.next().unwrap());
         Self { speed: pitch_speed, pitch_type, zone }
     }
     pub fn unparse(self) -> (String, u8) {
         let speed = format!("{:.1}", self.speed);
         // let speed = speed.strip_suffix(".0").unwrap_or(speed.as_str());
-        let pitch_info = format!("{speed} MPH {}", self.pitch_type.to_string());
+        let pitch_info = format!("{speed} MPH {}", maybe_recognized_to_string(&self.pitch_type));
         (pitch_info, self.zone)
     }
 }

--- a/src/game/weather.rs
+++ b/src/game/weather.rs
@@ -1,6 +1,6 @@
 use serde::{Serialize, Deserialize};
 
-use crate::utils::ExtraFields;
+use crate::utils::extra_fields_deserialize;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
@@ -9,6 +9,6 @@ pub struct Weather {
     pub name: String,
     pub tooltip: String,
 
-    #[serde(flatten)]
-    pub extra_fields: ExtraFields,
+    #[serde(flatten, deserialize_with = "extra_fields_deserialize")]
+    pub extra_fields: serde_json::Map<String, serde_json::Value>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod utils;
+pub(crate) mod utils;
 pub(crate) mod time;
 
 pub mod game;
@@ -14,4 +14,4 @@ pub use game::Game;
 pub use parsing::{process_event, process_game};
 pub use parsed_event::ParsedEventMessage;
 
-pub use utils::AddedLater;
+pub use utils::{NotRecognized, AddedLater};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub(crate) mod utils;
+pub mod utils;
 pub(crate) mod time;
 
 pub mod game;

--- a/src/nom_parsing/parse.rs
+++ b/src/nom_parsing/parse.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use nom::{branch::alt, bytes::complete::{tag, take_until}, character::complete::{digit1, u8}, combinator::{all_consuming, cut, fail, opt, rest}, error::context, multi::{many0, many1, separated_list1}, sequence::{delimited, preceded, separated_pair, terminated}, Finish, Parser};
 use phf::phf_map;
 
-use crate::{enums::{EventType, GameOverMessage, HomeAway, MaybeRecognized, MoundVisitType, NowBattingStats}, game::Event, nom_parsing::shared::{away_emoji_team, delivery, emoji, home_emoji_team, try_from_word, try_from_words_m_n, MyParser}, parsed_event::{FieldingAttempt, KnownBug, StartOfInningPitcher}, time::Breakpoints, ParsedEventMessage};
+use crate::{enums::{EventType, GameOverMessage, HomeAway, MoundVisitType, NowBattingStats}, game::Event, nom_parsing::shared::{away_emoji_team, delivery, emoji, home_emoji_team, try_from_word, try_from_words_m_n, MyParser}, parsed_event::{FieldingAttempt, KnownBug, StartOfInningPitcher}, time::Breakpoints, ParsedEventMessage};
 
 use super::{shared::{all_consuming_sentence_and, base_steal_sentence, bold, destination, emoji_team_eof, exclamation, fair_ball_type_verb_name, fielders_eof, fly_ball_type_verb_name, name_eof, now_batting_stats, ordinal_suffix, out, parse_and, parse_terminated, placed_player_eof, score_update, scores_and_advances, scores_sentence, sentence, sentence_eof, Error}, ParsingContext};
 
@@ -29,10 +29,10 @@ pub fn parse_event<'output, 'parse>(event: &'output Event, parsing_context: &Par
     }
     
     let event_type = match &event.event {
-        MaybeRecognized::Recognized(event_type) => event_type,
-        MaybeRecognized::NotRecognized(event_type) => {
+        Ok(event_type) => event_type,
+        Err(event_type) => {
             tracing::error!("Event type {event_type} not recognized: {}", event.message);
-            return Ok(ParsedEventMessage::ParseError { raw_event_type: event_type.to_string(), message: event.message.clone() })
+            return Ok(ParsedEventMessage::ParseError { raw_event_type: Err(event_type.clone()), message: event.message.clone() })
         }
     };
     

--- a/src/nom_parsing/parse_feed_event.rs
+++ b/src/nom_parsing/parse_feed_event.rs
@@ -1,7 +1,7 @@
 use nom::{branch::alt, bytes::complete::tag, character::complete::{i16, u8}, combinator::opt, error::context, multi::many1, sequence::{delimited, preceded, separated_pair, terminated}, Finish, Parser};
 use tracing::error;
 
-use crate::{enums::FeedEventType, feed_event::{AttributeChange, AttributeEqual, ParsedFeedEventText}, nom_parsing::shared::{emoji_team_eof, emojiless_item, feed_delivery, name_eof, parse_terminated, sentence_eof, try_from_word}};
+use crate::{enums::FeedEventType, feed_event::{AttributeChange, AttributeEqual, FeedEvent, ParsedFeedEventText}, nom_parsing::shared::{emoji_team_eof, emojiless_item, feed_delivery, name_eof, parse_terminated, sentence_eof, try_from_word}, utils::maybe_recognized_to_string};
 
 use super::shared::Error;
 
@@ -9,20 +9,24 @@ trait FeedEventParser<'output>: Parser<&'output str, Output = ParsedFeedEventTex
 impl<'output, T: Parser<&'output str, Output = ParsedFeedEventText<&'output str>, Error = Error<'output>>> FeedEventParser<'output> for T {}
 
 
-pub fn parse_feed_event<'output>(text: &'output str, event_type: FeedEventType) -> ParsedFeedEventText<&'output str> {
+pub fn parse_feed_event<'output>(event: &'output FeedEvent) -> ParsedFeedEventText<&'output str> {
+    let event_type = if let Ok(event_type) = event.event_type {event_type} else {
+        return ParsedFeedEventText::ParseError { event_type: maybe_recognized_to_string(&event.event_type), event_text: event.text.clone() }
+    };
+
     let result = match event_type {
-        FeedEventType::Game => game().parse(text),
-        FeedEventType::Augment => augment().parse(text),
+        FeedEventType::Game => game().parse(&event.text),
+        FeedEventType::Augment => augment().parse(&event.text),
     };
     match result.finish() {
         Ok(("", output)) => output,
         Ok((leftover, _)) => {
-            error!("{event_type} feed event parsed had leftover: {leftover} from {text}");
-            ParsedFeedEventText::ParseError { event_type: event_type.to_string(), event_text: text.to_string() }
+            error!("{event_type} feed event parsed had leftover: {leftover} from {}", &event.text);
+            ParsedFeedEventText::ParseError { event_type: event_type.to_string(), event_text: event.text.to_string() }
         }
         Err(o) => {
             error!("{event_type} feed event parse error: {o:?}");
-            ParsedFeedEventText::ParseError { event_type: event_type.to_string(), event_text: text.to_string() }
+            ParsedFeedEventText::ParseError { event_type: event_type.to_string(), event_text: event.text.to_string() }
         }
     }
 }

--- a/src/nom_parsing/parse_feed_event.rs
+++ b/src/nom_parsing/parse_feed_event.rs
@@ -1,7 +1,7 @@
 use nom::{branch::alt, bytes::complete::tag, character::complete::{i16, u8}, combinator::opt, error::context, multi::many1, sequence::{delimited, preceded, separated_pair, terminated}, Finish, Parser};
 use tracing::error;
 
-use crate::{enums::FeedEventType, feed_event::{AttributeChange, AttributeEqual, FeedEvent, ParsedFeedEventText}, nom_parsing::shared::{emoji_team_eof, emojiless_item, feed_delivery, name_eof, parse_terminated, sentence_eof, try_from_word}, utils::maybe_recognized_to_string};
+use crate::{enums::FeedEventType, feed_event::{AttributeChange, AttributeEqual, FeedEvent, FeedEventParseError, ParsedFeedEventText}, nom_parsing::shared::{emoji_team_eof, emojiless_item, feed_delivery, name_eof, parse_terminated, sentence_eof, try_from_word}};
 
 use super::shared::Error;
 
@@ -9,9 +9,10 @@ trait FeedEventParser<'output>: Parser<&'output str, Output = ParsedFeedEventTex
 impl<'output, T: Parser<&'output str, Output = ParsedFeedEventText<&'output str>, Error = Error<'output>>> FeedEventParser<'output> for T {}
 
 
-pub fn parse_feed_event<'output>(event: &'output FeedEvent) -> ParsedFeedEventText<&'output str> {
-    let event_type = if let Ok(event_type) = event.event_type {event_type} else {
-        return ParsedFeedEventText::ParseError { event_type: maybe_recognized_to_string(&event.event_type), event_text: event.text.clone() }
+pub fn parse_feed_event<'output>(event: &'output FeedEvent) -> Result<ParsedFeedEventText<&'output str>, FeedEventParseError> {
+    let event_type = match &event.event_type {
+        Ok(event_type) => event_type,
+        Err(e) => return Err(FeedEventParseError::EventTypeNotRecognized(e.clone()))
     };
 
     let result = match event_type {
@@ -19,14 +20,14 @@ pub fn parse_feed_event<'output>(event: &'output FeedEvent) -> ParsedFeedEventTe
         FeedEventType::Augment => augment().parse(&event.text),
     };
     match result.finish() {
-        Ok(("", output)) => output,
+        Ok(("", output)) => Ok(output),
         Ok((leftover, _)) => {
             error!("{event_type} feed event parsed had leftover: {leftover} from {}", &event.text);
-            ParsedFeedEventText::ParseError { event_type: event_type.to_string(), event_text: event.text.to_string() }
+            Err(FeedEventParseError::FailedParsingText { event_type: *event_type, text: event.text.clone() })
         }
         Err(o) => {
             error!("{event_type} feed event parse error: {o:?}");
-            ParsedFeedEventText::ParseError { event_type: event_type.to_string(), event_text: event.text.to_string() }
+            Err(FeedEventParseError::FailedParsingText { event_type: *event_type, text: event.text.clone() })
         }
     }
 }

--- a/src/nom_parsing/shared.rs
+++ b/src/nom_parsing/shared.rs
@@ -27,10 +27,10 @@ impl<'output, 'parse> ParsingContext<'output, 'parse> {
         }
     }
     pub(crate) fn before(&self, breakpoint: Breakpoints) -> bool {
-        breakpoint.before(self.game.season, &self.game.day, self.event_index)
+        breakpoint.before(self.game.season, self.game.day.as_ref().copied().ok(), self.event_index)
     }
     pub(crate) fn after(&self, breakpoint: Breakpoints) -> bool {
-        breakpoint.after(self.game.season, &self.game.day, self.event_index)
+        breakpoint.after(self.game.season, self.game.day.as_ref().copied().ok(), self.event_index)
     }
 }
 

--- a/src/parsed_event.rs
+++ b/src/parsed_event.rs
@@ -22,6 +22,10 @@ pub enum GameEventParseError {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, EnumDiscriminants)]
 #[serde(tag = "event_type")]
 pub enum ParsedEventMessage<S> {
+    ParseError {
+        error: GameEventParseError,
+        message: S
+    },
     KnownBug {
         bug: KnownBug<S>
     },
@@ -125,6 +129,7 @@ impl<S: Display> ParsedEventMessage<S> {
     /// Recreate the event message this ParsedEvent was built out of.
     pub fn unparse(&self, game: &Game, event_index: Option<u16>) -> String {
         match self {
+            Self::ParseError { message, .. } => message.to_string(),
             Self::LiveNow { away_team, home_team } => format!("{} @ {}", away_team, home_team),
             Self::PitchingMatchup { away_team, home_team, home_pitcher, away_pitcher } => format!("{away_team} {away_pitcher} vs. {home_team} {home_pitcher}"),
             Self::Lineup { side: _, players } => {

--- a/src/parsed_event.rs
+++ b/src/parsed_event.rs
@@ -3,7 +3,7 @@ use std::{fmt::{Display, Write}, iter::once};
 use serde::{Serialize, Deserialize};
 use strum::EnumDiscriminants;
 
-use crate::{enums::{Base, BaseNameVariant, BatterStat, Distance, FairBallDestination, FairBallType, FieldingErrorType, FoulType, GameOverMessage, HomeAway, ItemPrefix, ItemSuffix, ItemType, MoundVisitType, NowBattingStats, Place, StrikeType, TopBottom}, Game, time::Breakpoints};
+use crate::{enums::{Base, BaseNameVariant, BatterStat, Distance, EventType, FairBallDestination, FairBallType, FieldingErrorType, FoulType, GameOverMessage, HomeAway, ItemPrefix, ItemSuffix, ItemType, MoundVisitType, NowBattingStats, Place, StrikeType, TopBottom}, time::Breakpoints, utils::MaybeRecognizedResult, Game};
 
 /// S is the string type used. S = &'output str is used by the parser, 
 /// but a mutable type is necessary when directly deserializing, because some players have escaped characters in their names
@@ -11,7 +11,7 @@ use crate::{enums::{Base, BaseNameVariant, BatterStat, Distance, FairBallDestina
 #[serde(tag = "event_type")]
 pub enum ParsedEventMessage<S> {
     ParseError {
-        raw_event_type: String,
+        raw_event_type: MaybeRecognizedResult<EventType>,
         message: String,
     },
     KnownBug {
@@ -513,7 +513,7 @@ impl<S: Display> Delivery<S> {
 }
 
 fn old_space(game: &Game, event_index: Option<u16>) -> &'static str {
-    if Breakpoints::S2D169.before(game.season, &game.day, event_index) {
+    if Breakpoints::S2D169.before(game.season, game.day.as_ref().copied().ok(), event_index) {
         " "
     } else {
         ""

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -18,7 +18,7 @@ pub fn process_event<'output, 'parse>(event: &'output Event, game: &'output Game
         Ok(event) => event,
         Err(e) => {
             error!("Parse error: for {:?}: {e}", &event.event);
-            ParsedEventMessage::ParseError { raw_event_type: event.event.to_string(), message: event.message.clone() }
+            ParsedEventMessage::ParseError { raw_event_type: event.event.clone(), message: event.message.clone() }
         }
     };
     parsed_event_message

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,8 +1,7 @@
-use crate::{game::Event, nom_parsing::{parse_event, ParsingContext}, parsed_event::{GameEventParseError, ParsedEventMessage}, Game};
-use tracing::error;
+use crate::{game::Event, nom_parsing::{parse_event, ParsingContext}, parsed_event::ParsedEventMessage, Game};
 
 /// Convenience method to call process_event for every event in a game
-pub fn process_game<'output, 'parse>(game: &'output Game, game_id: &'parse str) -> Vec<Result<ParsedEventMessage<&'output str>, GameEventParseError>> {
+pub fn process_game<'output, 'parse>(game: &'output Game, game_id: &'parse str) -> Vec<ParsedEventMessage<&'output str>> {
     let mut result = Vec::new();
 
     for event in &game.event_log {
@@ -12,12 +11,9 @@ pub fn process_game<'output, 'parse>(game: &'output Game, game_id: &'parse str) 
 }
 
 /// Processes an event into a ParsedEventMessage. Zero-copy parsing, the strings in the returned ParsedEventMessage are references to the strings in event and game.
-pub fn process_event<'output, 'parse>(event: &'output Event, game: &'output Game, game_id: &'parse str) -> Result<ParsedEventMessage<&'output str>, GameEventParseError> {
+pub fn process_event<'output, 'parse>(event: &'output Event, game: &'output Game, game_id: &'parse str) -> ParsedEventMessage<&'output str> {
     let parsing_context = ParsingContext::new(game_id, game, event.index);
     let parsed_event_message = parse_event(event, &parsing_context);
-    if let Err(e) = &parsed_event_message {
-        error!("Parse error for {:?}: {e}", &event.event);
-    }
     parsed_event_message
 }
 

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -29,10 +29,14 @@ pub fn process_event<'output, 'parse>(event: &'output Event, game: &'output Game
 mod test {
     use std::{error::Error, fs::File, io::Read};
 
-    use crate::{process_game, Game, ParsedEventMessage};
+    
+
+    use crate::{process_game, utils::no_tracing_errs, Game, ParsedEventMessage};
 
     #[test]
     fn livingston() -> Result<(), Box<dyn Error>> {
+        let no_tracing_errors = no_tracing_errs();
+
         let f = File::open("test_data/livingston_game.json")?;
         let game:Game = serde_json::from_reader(f)?;
 
@@ -53,6 +57,7 @@ mod test {
             assert!(diff.is_none(), "{diff:?}");
         }
 
+        drop(no_tracing_errors);
         Ok(())
     }
 }

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -37,7 +37,8 @@ pub struct Player {
     pub home: String,
 
 
-    greater_boon: ExpectNone,
+    #[serde_as(as = "ExpectNone<_>")]
+    greater_boon: Option<serde_json::Value>,
     pub lesser_boon: Option<Boon>,
     pub modifications: Vec<Modification>,
 
@@ -192,17 +193,16 @@ pub struct Boon {
 #[cfg(test)]
 mod test {
     use std::path::Path;
-
-    use tracing_test::traced_test;
-
-    use crate::{player::Player, utils::assert_round_trip};
+    use crate::{player::Player, utils::{assert_round_trip, no_tracing_errs}};
 
 
     #[test]
-    #[traced_test]
     fn player_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+        let no_tracing_errs = no_tracing_errs();
+
         assert_round_trip::<Player>(Path::new("test_data/s2_player.json"))?;
-        assert!(!logs_contain("not recognized"));
+
+        drop(no_tracing_errs);
         Ok(())
     }
 }

--- a/src/team/raw_team.rs
+++ b/src/team/raw_team.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::{Serialize, Deserialize};
 use serde_with::serde_as;
 
-use crate::{enums::{GameStat, PositionType, Slot}, utils::{maybe_recognized_from_str, maybe_recognized_to_string, AddedLaterResult, ExtraFields, MaybeRecognizedResult}, AddedLater};
+use crate::{enums::{GameStat, PositionType, Slot}, utils::{maybe_recognized_from_str, maybe_recognized_to_string, AddedLaterResult, extra_fields_deserialize, MaybeRecognizedResult}, AddedLater};
 use crate::utils::{MaybeRecognizedHelper, AddedLaterHelper};
 use super::team::TeamPlayer;
 
@@ -28,8 +28,8 @@ pub(crate) struct RawTeamPlayer {
     #[serde(default = "AddedLaterHelper::default_result", skip_serializing_if = "AddedLaterResult::is_err")]
     pub stats: AddedLaterResult<HashMap<MaybeRecognizedResult<GameStat>, i32>>,
 
-    #[serde(flatten)]
-    pub extra_fields: ExtraFields,
+    #[serde(flatten, deserialize_with = "extra_fields_deserialize")]
+    pub extra_fields: serde_json::Map<String, serde_json::Value>,
 }
 
 impl From<RawTeamPlayer> for TeamPlayer {

--- a/src/team/raw_team.rs
+++ b/src/team/raw_team.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 
 use serde::{Serialize, Deserialize};
+use serde_with::serde_as;
 
-use crate::{enums::{GameStat, MaybeRecognized, PositionType, Slot}, utils::ExtraFields, AddedLater};
+use crate::{enums::{GameStat, PositionType, Slot}, utils::{maybe_recognized_from_str, maybe_recognized_to_string, AddedLaterResult, ExtraFields, MaybeRecognizedResult}, AddedLater};
+use crate::utils::{MaybeRecognizedHelper, AddedLaterHelper};
 use super::team::TeamPlayer;
 
-
+#[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub(crate) struct RawTeamPlayer {
@@ -16,12 +18,15 @@ pub(crate) struct RawTeamPlayer {
     #[serde(rename = "PlayerID")]
     pub player_id: String,
     pub position: String,
-    pub slot: MaybeRecognized<Slot>,
-    #[serde(default, skip_serializing_if = "AddedLater::skip")]
-    pub position_type: AddedLater<MaybeRecognized<PositionType>>,
+    #[serde_as(as = "MaybeRecognizedHelper<_>")]
+    pub slot: MaybeRecognizedResult<Slot>,
+    #[serde_as(as = "AddedLaterHelper<MaybeRecognizedHelper<_>>")]
+    #[serde(default = "AddedLaterHelper::default_result", skip_serializing_if = "AddedLaterResult::is_err")]
+    pub position_type: AddedLaterResult<MaybeRecognizedResult<PositionType>>,
 
-    #[serde(default, skip_serializing_if = "AddedLater::skip")]
-    pub stats: AddedLater<HashMap<MaybeRecognized<GameStat>, i32>>,
+    #[serde_as(as = "AddedLaterHelper<HashMap<MaybeRecognizedHelper<_>, _>>")]
+    #[serde(default = "AddedLaterHelper::default_result", skip_serializing_if = "AddedLaterResult::is_err")]
+    pub stats: AddedLaterResult<HashMap<MaybeRecognizedResult<GameStat>, i32>>,
 
     #[serde(flatten)]
     pub extra_fields: ExtraFields,
@@ -31,11 +36,11 @@ impl From<RawTeamPlayer> for TeamPlayer {
     fn from(value: RawTeamPlayer) -> Self {
         let RawTeamPlayer { emoji, first_name, last_name, number, player_id, position, slot, position_type, stats, extra_fields } = value;
 
-        let position_type_overidden = position_type.is_none();
-        let position_type = position_type.into_inner().unwrap_or_else(|| MaybeRecognized::<PositionType>::from(position.as_str()));
+        let position_type_overidden = position_type.is_err();
+        let position_type = position_type.unwrap_or_else(|_| maybe_recognized_from_str(&position));
 
         // Undrafted player's positions are just their slot
-        let position = (player_id != "#").then(|| position.as_str().into());
+        let position = (player_id != "#").then(|| maybe_recognized_from_str(&position));
 
         TeamPlayer { emoji, first_name, last_name, number, player_id, position, slot, position_type, stats, position_type_overidden, extra_fields }
     }
@@ -46,12 +51,12 @@ impl From<TeamPlayer> for RawTeamPlayer {
         let TeamPlayer { emoji, first_name, last_name, number, player_id, position, slot, position_type, stats, position_type_overidden, extra_fields } = value;
 
         let position = match (position, position_type_overidden) {
-            (Some(position), _) => position.to_string(),
-            (None, true) => position_type.to_string(),
-            (None, false) => slot.to_string()
+            (Some(position), _) => maybe_recognized_to_string(&position),
+            (None, true) => maybe_recognized_to_string(&position_type),
+            (None, false) => maybe_recognized_to_string(&slot)
         };
 
-        let position_type = AddedLater((!position_type_overidden).then_some(position_type));
+        let position_type = (!position_type_overidden).then_some(position_type).ok_or(AddedLater);
 
         RawTeamPlayer { emoji, first_name, last_name, number, player_id, position, slot, position_type, stats, extra_fields }
     }


### PR DESCRIPTION
Breaking:
- Use serde_as instead of wrapper types for custom (de)serialization
  - MaybeRecognized replaced with Result
  - SomeOrEmptyString replaced with Option
- Add error types AddedLater, NotRecognized, FeedEventParseError, GameEventParseError,
  - ParseError updated for ParsedFeedEventText and ParsedEventMessage