### PR TITLE
Falling star support

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -28,6 +28,7 @@ pub enum EventType {
     #[serde(rename = "Weather_Delivery")]
     WeatherDelivery,
     FallingStar,
+    Weather,
 
     // Season 2
     #[strum(to_string = "Weather_Shipment")]
@@ -884,6 +885,7 @@ pub enum SeasonStatus {
     SuperstarGame,
     Holiday,
     PostseasonRound(u8),
+    SpecialEvent
 }
 impl FromStr for SeasonStatus {
     type Err = &'static str;
@@ -894,6 +896,7 @@ impl FromStr for SeasonStatus {
             "Home Run Challenge" => Ok(SeasonStatus::HomeRunChallenge),
             "Holiday" => Ok(SeasonStatus::Holiday),
             "Superstar Game" => Ok(SeasonStatus::SuperstarGame),
+            "Special Event" => Ok(SeasonStatus::SpecialEvent),
             s => s.strip_prefix("Postseason Round ")
                         .and_then(|s| s.parse().ok())
                         .map(SeasonStatus::PostseasonRound)
@@ -910,7 +913,8 @@ impl Display for SeasonStatus {
             SeasonStatus::HomeRunChallenge => Display::fmt("Home Run Challenge", f),
             SeasonStatus::SuperstarGame => Display::fmt("Superstar Game", f),
             SeasonStatus::Holiday => Display::fmt("Holiday", f),
-            SeasonStatus::PostseasonRound(i) => write!(f, "Postseason Round {i}")
+            SeasonStatus::PostseasonRound(i) => write!(f, "Postseason Round {i}"),
+            SeasonStatus::SpecialEvent => write!(f, "Special Event")
         }
     }
 }
@@ -1254,7 +1258,8 @@ pub enum MoundVisitType {
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, EnumIter, PartialEq, Eq, Hash, EnumString, Display)]
 pub enum LeagueScale {
     Lesser,
-    Greater
+    Greater,
+    Special
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, EnumIter, PartialEq, Eq, Hash, EnumString, Display)]

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -27,6 +27,7 @@ pub enum EventType {
     #[strum(to_string = "Weather_Delivery")]
     #[serde(rename = "Weather_Delivery")]
     WeatherDelivery,
+    FallingStar,
 
     // Season 2
     #[strum(to_string = "Weather_Shipment")]

--- a/src/nom_parsing/parse.rs
+++ b/src/nom_parsing/parse.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use nom::{branch::alt, bytes::complete::{tag, take_until}, character::complete::{digit1, u8}, combinator::{all_consuming, cut, fail, opt, rest}, error::context, multi::{many0, many1, separated_list1}, sequence::{delimited, preceded, separated_pair, terminated}, Finish, Parser};
 use phf::phf_map;
 
-use crate::{enums::{EventType, GameOverMessage, HomeAway, MoundVisitType, NowBattingStats}, game::Event, nom_parsing::shared::{away_emoji_team, delivery, emoji, home_emoji_team, try_from_word, try_from_words_m_n, MyParser}, parsed_event::{FieldingAttempt, GameEventParseError, KnownBug, StartOfInningPitcher}, time::Breakpoints, ParsedEventMessage};
+use crate::{enums::{EventType, GameOverMessage, HomeAway, MoundVisitType, NowBattingStats}, game::Event, nom_parsing::shared::{away_emoji_team, delivery, emoji, home_emoji_team, try_from_word, try_from_words_m_n, MyParser}, parsed_event::{FieldingAttempt, GameEventParseError, KnownBug, StartOfInningPitcher, FallingStarOutcome}, time::Breakpoints, ParsedEventMessage};
 
 use super::{shared::{all_consuming_sentence_and, base_steal_sentence, bold, destination, emoji_team_eof, exclamation, fair_ball_type_verb_name, fielders_eof, fly_ball_type_verb_name, name_eof, now_batting_stats, ordinal_suffix, out, parse_and, parse_terminated, placed_player_eof, score_update, scores_and_advances, scores_sentence, sentence, sentence_eof}, ParsingContext};
 
@@ -53,6 +53,7 @@ pub fn parse_event<'output, 'parse>(event: &'output Event, parsing_context: &Par
         EventType::NowBatting => now_batting().parse(&event.message),
         EventType::WeatherDelivery => weather_delivery(parsing_context).parse(&event.message),
         EventType::FallingStar => falling_star().parse(&event.message),
+        EventType::Weather => weather().parse(&event.message),
         EventType::WeatherShipment => weather_shipment(parsing_context).parse(&event.message),
         EventType::WeatherSpecialDelivery => special_delivery(parsing_context).parse(&event.message),
         EventType::Balk => balk().parse(&event.message)
@@ -98,6 +99,55 @@ fn falling_star<'output>() -> impl MyParser<'output, ParsedEventMessage<&'output
     context("Falling Star", all_consuming(
         preceded(tag("<strong>🌠 "), parse_terminated(" is hit by a Falling Star!</strong>"))
             .map(|player_name| ParsedEventMessage::FallingStar { player_name }),
+    ))
+}
+
+fn weather<'output>() -> impl MyParser<'output, ParsedEventMessage<&'output str>> {
+    context("Weather", all_consuming(
+        |input| {
+            let (input, _) = tag(" <strong>").parse(input)?;
+            
+            let (input, deflection) = opt(|input| {
+                let (input, _) = tag("It deflected off ").parse(input)?;
+                
+                let (input, deflected_off) = parse_terminated(" and struck ").parse(input)?;
+                let (input, and_struck) = parse_terminated("!</strong> <strong>").parse(input)?;
+                
+                Ok((input, (deflected_off, and_struck)))
+            }).parse(input)?;
+            
+            // These are very repetitive, but one is matching a name and the other is parsing a name
+            // so I don't see an obvious way to genericize them
+            if let Some((deflected_off, and_struck)) = deflection {
+                let (input, _) = tag(and_struck).parse(input)?;
+                
+                let (input, outcome) = alt((
+                    tag(" was injured by the extreme force of the impact!</strong>")
+                        .map(|_|  FallingStarOutcome::Injury ),
+                    tag(" was infused with a glimmer of celestial energy!</strong>")
+                        .map(|_|  FallingStarOutcome::InfusionI ),
+                    tag("  began to glow brightly with celestial energy!</strong>")
+                        .map(|_|  FallingStarOutcome::InfusionII ),
+                    tag(" was fully charged with an abundance of celestial energy!</strong>")
+                        .map(|_|  FallingStarOutcome::InfusionIII )
+                )).parse(input)?;
+                
+                Ok((input, ParsedEventMessage::FallingStarOutcome { deflection: Some(deflected_off), player_name: and_struck, outcome }))
+            } else {
+                let (input, (player_name, outcome)) = alt((
+                    parse_terminated(" was injured by the extreme force of the impact!</strong>")
+                        .map(|name| (name, FallingStarOutcome::Injury)),
+                    parse_terminated(" was infused with a glimmer of celestial energy!</strong>")
+                        .map(|name| (name, FallingStarOutcome::InfusionI)),
+                    parse_terminated("  began to glow brightly with celestial energy!</strong>")
+                        .map(|name| (name, FallingStarOutcome::InfusionII)),
+                    parse_terminated(" was fully charged with an abundance of celestial energy!</strong>")
+                        .map(|name| (name, FallingStarOutcome::InfusionIII)),
+                )).parse(input)?;
+                
+                Ok((input, ParsedEventMessage::FallingStarOutcome { deflection: None, player_name, outcome }))
+            }
+        },
     ))
 }
 

--- a/src/nom_parsing/parse.rs
+++ b/src/nom_parsing/parse.rs
@@ -52,6 +52,7 @@ pub fn parse_event<'output, 'parse>(event: &'output Event, parsing_context: &Par
         EventType::PlayBall => play_ball().parse(&event.message),
         EventType::NowBatting => now_batting().parse(&event.message),
         EventType::WeatherDelivery => weather_delivery(parsing_context).parse(&event.message),
+        EventType::FallingStar => falling_star().parse(&event.message),
         EventType::WeatherShipment => weather_shipment(parsing_context).parse(&event.message),
         EventType::WeatherSpecialDelivery => special_delivery(parsing_context).parse(&event.message),
         EventType::Balk => balk().parse(&event.message)
@@ -90,6 +91,13 @@ fn weather_shipment<'output, 'parse>(parsing_context: &'parse ParsingContext<'ou
 fn weather_delivery<'output, 'parse>(parsing_context: &'parse ParsingContext<'output, 'parse>) -> impl MyParser<'output, ParsedEventMessage<&'output str>> + 'parse {
     context("Weather Delivery", all_consuming(
         delivery(parsing_context, "Delivery").map(|delivery| ParsedEventMessage::WeatherDelivery { delivery })
+    ))
+}
+
+fn falling_star<'output>() -> impl MyParser<'output, ParsedEventMessage<&'output str>> {
+    context("Falling Star", all_consuming(
+        preceded(tag("<strong>🌠 "), parse_terminated(" is hit by a Falling Star!</strong>"))
+            .map(|player_name| ParsedEventMessage::FallingStar { player_name }),
     ))
 }
 

--- a/src/nom_parsing/parse.rs
+++ b/src/nom_parsing/parse.rs
@@ -126,7 +126,7 @@ fn weather<'output>() -> impl MyParser<'output, ParsedEventMessage<&'output str>
                         .map(|_|  FallingStarOutcome::Injury ),
                     tag(" was infused with a glimmer of celestial energy!</strong>")
                         .map(|_|  FallingStarOutcome::InfusionI ),
-                    tag("  began to glow brightly with celestial energy!</strong>")
+                    tag(" began to glow brightly with celestial energy!</strong>")
                         .map(|_|  FallingStarOutcome::InfusionII ),
                     tag(" was fully charged with an abundance of celestial energy!</strong>")
                         .map(|_|  FallingStarOutcome::InfusionIII )
@@ -139,7 +139,7 @@ fn weather<'output>() -> impl MyParser<'output, ParsedEventMessage<&'output str>
                         .map(|name| (name, FallingStarOutcome::Injury)),
                     parse_terminated(" was infused with a glimmer of celestial energy!</strong>")
                         .map(|name| (name, FallingStarOutcome::InfusionI)),
-                    parse_terminated("  began to glow brightly with celestial energy!</strong>")
+                    parse_terminated(" began to glow brightly with celestial energy!</strong>")
                         .map(|name| (name, FallingStarOutcome::InfusionII)),
                     parse_terminated(" was fully charged with an abundance of celestial energy!</strong>")
                         .map(|name| (name, FallingStarOutcome::InfusionIII)),

--- a/src/parsed_event.rs
+++ b/src/parsed_event.rs
@@ -111,6 +111,7 @@ pub enum ParsedEventMessage<S> {
 
     // Season 1
     WeatherDelivery { delivery: Delivery<S> },
+    FallingStar { player_name: S },
 
     // Season 2
     WeatherShipment {
@@ -313,6 +314,9 @@ impl<S: Display> ParsedEventMessage<S> {
             }
             Self::WeatherDelivery {delivery } => {
                 delivery.unparse("Delivery")
+            },
+            Self::FallingStar { player_name } => {
+                format!("<strong>🌠 {player_name} is hit by a Falling Star!</strong>")
             },
             Self::WeatherShipment { deliveries } => {
                 deliveries.iter().map(|d| d.unparse("Shipment")).collect::<Vec<String>>().join(" ")

--- a/src/parsed_event.rs
+++ b/src/parsed_event.rs
@@ -112,6 +112,7 @@ pub enum ParsedEventMessage<S> {
     // Season 1
     WeatherDelivery { delivery: Delivery<S> },
     FallingStar { player_name: S },
+    FallingStarOutcome { deflection: Option<S>, player_name: S, outcome: FallingStarOutcome },
 
     // Season 2
     WeatherShipment {
@@ -318,6 +319,22 @@ impl<S: Display> ParsedEventMessage<S> {
             Self::FallingStar { player_name } => {
                 format!("<strong>🌠 {player_name} is hit by a Falling Star!</strong>")
             },
+            Self::FallingStarOutcome { deflection, player_name, outcome } => {
+                let deflection_msg = if let Some(deflected_off_player_name) = deflection {
+                    format!("It deflected off {deflected_off_player_name} and struck {player_name}!</strong> <strong>")
+                } else {
+                    String::new()
+                };
+                
+                let outcome_msg = match outcome {
+                    FallingStarOutcome::Injury => "was injured by the extreme force of the impact!",
+                    FallingStarOutcome::InfusionI => "was infused with a glimmer of celestial energy!",
+                    FallingStarOutcome::InfusionII => "began to glow brightly with celestial energy!",
+                    FallingStarOutcome::InfusionIII => "was fully charged with an abundance of celestial energy!",
+                };
+                
+                format!(" <strong>{deflection_msg}{player_name} {outcome_msg}</strong>")
+            },
             Self::WeatherShipment { deliveries } => {
                 deliveries.iter().map(|d| d.unparse("Shipment")).collect::<Vec<String>>().join(" ")
             }
@@ -470,6 +487,14 @@ impl<S> TryFrom<BaseSteal<S>> for RunnerAdvance<S> {
             Err(())
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub enum FallingStarOutcome {
+    Injury,
+    InfusionI,
+    InfusionII,
+    InfusionIII
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
Support `FallingStar` events and the `Weather` events that follow them.

I tried to write this in the compositional style you use but I couldn't wrap my head around it. I went back to the imperative style I'm used to.

I verified it worked on a random Falling Stars game using the `parser` binary, which also necessitated adding some new variants to `SeasonStatus` and `LeagueScale`.