### PR TITLE
Pre-s6 fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "mmolb_parsing"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "async-stream",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmolb_parsing"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2021"
 default-run = "parser"
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1409,7 +1409,8 @@ pub enum Handedness {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, EnumIter, PartialEq, Eq, Hash, EnumString, IntoStaticStr, Display)]
 pub enum EquipmentEffectType {
-    FlatBonus
+    FlatBonus,
+    Multiplier
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, EnumIter, PartialEq, Eq, Hash, EnumString, IntoStaticStr, Display)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,4 @@ pub use game::Game;
 pub use parsing::{process_event, process_game};
 pub use parsed_event::ParsedEventMessage;
 
-pub use utils::{NotRecognized, AddedLater, RemovedLater, AddedLaterResult, RemovedLaterResult, MaybeRecognizedResult};
+pub use utils::{NotRecognized, AddedLater, RemovedLater, AddedLaterResult, RemovedLaterResult, MaybeRecognizedResult, EmptyArrayOr};

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 pub use serde::{Serialize, Deserialize};
 use serde_with::serde_as;
-use crate::{enums::{Attribute, Day, EquipmentEffectType, EquipmentRarity, EquipmentSlot, GameStat, Handedness, ItemPrefix, ItemSuffix, ItemName, SpecialItemType, Position, PositionType, SeasonStatus}, feed_event::FeedEvent, utils::{AddedLaterResult, ExpectNone, MaybeRecognizedResult, RemovedLaterResult, StarHelper}, NotRecognized};
+
+use crate::{enums::{Attribute, Day, EquipmentEffectType, EquipmentRarity, EquipmentSlot, GameStat, Handedness, ItemPrefix, ItemSuffix, ItemName, SpecialItemType, Position, PositionType, SeasonStatus}, feed_event::FeedEvent, utils::{AddedLaterResult, ExpectNone, MaybeRecognizedResult, RemovedLaterResult, StarHelper}};
 use crate::utils::{MaybeRecognizedHelper, SometimesMissingHelper, extra_fields_deserialize};
 
 // I really wanted to make this generic, but I cannot figure out the magic necessary to

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
 pub use serde::{Serialize, Deserialize};
-use serde::{Serializer};
-use serde::de::{SeqAccess, Visitor};
-use serde_with::{serde_as, SerializeAs};
+use serde_with::serde_as;
 use crate::{enums::{Attribute, Day, EquipmentEffectType, EquipmentRarity, EquipmentSlot, GameStat, Handedness, ItemPrefix, ItemSuffix, ItemName, SpecialItemType, Position, PositionType, SeasonStatus}, feed_event::FeedEvent, utils::{AddedLaterResult, ExpectNone, MaybeRecognizedResult, RemovedLaterResult, StarHelper}, NotRecognized};
 use crate::utils::{MaybeRecognizedHelper, SometimesMissingHelper, extra_fields_deserialize};
 

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -2,20 +2,8 @@ use std::collections::HashMap;
 pub use serde::{Serialize, Deserialize};
 use serde_with::serde_as;
 
-use crate::{enums::{Attribute, Day, EquipmentEffectType, EquipmentRarity, EquipmentSlot, GameStat, Handedness, ItemPrefix, ItemSuffix, ItemName, SpecialItemType, Position, PositionType, SeasonStatus}, feed_event::FeedEvent, utils::{AddedLaterResult, ExpectNone, MaybeRecognizedResult, RemovedLaterResult, StarHelper}};
+use crate::{enums::{Attribute, Day, EquipmentEffectType, EquipmentRarity, EquipmentSlot, GameStat, Handedness, ItemName, ItemPrefix, ItemSuffix, Position, PositionType, SeasonStatus, SpecialItemType}, feed_event::FeedEvent, utils::{AddedLaterResult, ExpectNone, MaybeRecognizedResult, RemovedLaterResult, StarHelper}, EmptyArrayOr};
 use crate::utils::{MaybeRecognizedHelper, SometimesMissingHelper, extra_fields_deserialize};
-
-// I really wanted to make this generic, but I cannot figure out the magic necessary to
-// let serde_as see through the type
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub enum SeasonStats {
-    // The empty array exists for serde to have something to match. I wanted to get rid
-    // of it with serde_as but couldn't figure it out
-    EmptyArray([(); 0]),
-    Value(#[serde_as(as = "HashMap<_, HashMap<MaybeRecognizedHelper<_>, _>>")] HashMap<String, HashMap<MaybeRecognizedResult<SeasonStatus>, String>>),
-}
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -63,7 +51,8 @@ pub struct Player {
     #[serde_as(as = "MaybeRecognizedHelper<_>")]
     pub position_type: MaybeRecognizedResult<PositionType>,
 
-    pub season_stats: SeasonStats,
+    #[serde_as(as = "EmptyArrayOr<HashMap<_, HashMap<MaybeRecognizedHelper<_>, _>>>")]
+    pub season_stats: EmptyArrayOr<HashMap<String, HashMap<MaybeRecognizedResult<SeasonStatus>, String>>>,
     #[serde_as(as = "HashMap<_, HashMap<MaybeRecognizedHelper<_>, _>>")]
     pub stats: HashMap<String, HashMap<MaybeRecognizedResult<GameStat>, i32>>,
 

--- a/src/team/team.rs
+++ b/src/team/team.rs
@@ -52,7 +52,9 @@ pub struct Team {
     #[serde(default = "SometimesMissingHelper::default_result", skip_serializing_if = "Result::is_err")]
     #[serde_as(as = "SometimesMissingHelper<_>")]
     pub augments: RemovedLaterResult<u16>,
-    pub championships: u8,
+    #[serde(default = "SometimesMissingHelper::default_result", skip_serializing_if = "Result::is_err")]
+    #[serde_as(as = "SometimesMissingHelper<_>")]
+    pub championships: RemovedLaterResult<u8>,
     pub color: String,
     pub emoji: String,
 

--- a/src/team/team.rs
+++ b/src/team/team.rs
@@ -52,9 +52,8 @@ pub struct Team {
     #[serde(default = "SometimesMissingHelper::default_result", skip_serializing_if = "Result::is_err")]
     #[serde_as(as = "SometimesMissingHelper<_>")]
     pub augments: RemovedLaterResult<u16>,
-    #[serde(default = "SometimesMissingHelper::default_result", skip_serializing_if = "Result::is_err")]
-    #[serde_as(as = "SometimesMissingHelper<_>")]
-    pub championships: RemovedLaterResult<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub championships: Option<u8>,
     pub color: String,
     pub emoji: String,
 


### PR DESCRIPTION
As I write this it includes:

- Make team Championships optional, since there's now one (1) team without that field
- Support a (presumably erroneous) empty array in player SeasonStats instead of an empty object. I tried to do this in a generic way and couldn't figure out how to satisfy serde_as, so it's a one-off solution. I would be happy to see it rewritten properly.
- Add Multiplier variant to EquipmentEffectType

Knowing me, the longer this exists the more I will add to it